### PR TITLE
Add support for main branches with other names (#8)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,12 +34,16 @@ Keys:
 ``github_project``
    The project name on GitHub.
 
+``main_branch``
+   The name of the main branch to compare against and tag.
+
 ``bugzilla_product`` (optional)
-   The product for this project in Bugzilla.
+   The product for this project in Bugzilla. You only need to set this
+   if you're going to call ``make-bug``.
 
 ``bugzilla_component`` (optional)
-   The component for this project in Bugzilla.
-
+   The component for this project in Bugzilla. You only need to set this
+   if you're going to call ``make-bug``.
 
 Example ``setup.cfg`` for this project:
 
@@ -48,6 +52,7 @@ Example ``setup.cfg`` for this project:
    [tool:release]
    github_user = willkg
    github_project = socorro-release
+   main_branch = main
 
 
 Usage
@@ -82,7 +87,7 @@ History
 =======
 
 This is loosely based on a deploy-bug script I wrote and Peter's make-tag
-script. I merged them together and rewrote some bits and that's what we've
-got now.
+script. I merged them together and rewrote some bits and that's what we've got
+now.
 
 Many thanks to Peter for his work on make-tag!

--- a/release.py
+++ b/release.py
@@ -44,6 +44,8 @@ DEFAULT_CONFIG = {
     # GitHub user and project name
     "github_user": "",
     "github_project": "",
+    # The name of the main branch
+    "main_branch": "",
 }
 
 LINE = "=" * 80
@@ -90,8 +92,8 @@ def fetch(url, is_json=True):
     return data
 
 
-def fetch_history_from_github(owner, repo, from_rev):
-    url = f"{GITHUB_API}repos/{owner}/{repo}/compare/{from_rev}...master"
+def fetch_history_from_github(owner, repo, from_rev, main_branch):
+    url = f"{GITHUB_API}repos/{owner}/{repo}/compare/{from_rev}...{main_branch}"
     return fetch(url)
 
 
@@ -213,10 +215,21 @@ def run():
 
     args = parser.parse_args()
 
-    # Let's make sure we're up-to-date and on master branch
+    github_project = args.github_project
+    github_user = args.github_user
+    main_branch = args.main_branch
+
+    if not github_project or not github_user or not main_branch:
+        print("main_branch, github_project, and github_user are required.")
+        print("Either set them in setup.cfg or specify them as command line arguments.")
+        return 1
+
+    # Let's make sure we're up-to-date and on main branch
     current_branch = check_output("git rev-parse --abbrev-ref HEAD")
-    if current_branch != "master":
-        print(f"Must be on the master branch to do this (not {current_branch})")
+    if current_branch != main_branch:
+        print(
+            f"Must be on the {main_branch} branch to do this; currently on {current_branch}"
+        )
         return 1
 
     # The current branch can't be dirty
@@ -229,19 +242,10 @@ def run():
         )
         return 1
 
-    github_project = args.github_project
-    github_user = args.github_user
-
-    if not github_project or not github_user:
-        print(
-            "github_project and github_user are required. Either set them in "
-            "setup.cfg or specify them as command line arguments."
-        )
-        return 1
     remote_name = get_remote_name(github_user)
 
     # Get existing git tags from remote
-    check_output(f"git pull {remote_name} master --tags", stderr=subprocess.STDOUT)
+    check_output(f"git pull {remote_name} {main_branch} --tags", stderr=subprocess.STDOUT)
 
     # Figure out the most recent tag details
     last_tag = check_output(
@@ -255,7 +259,7 @@ def run():
         print(last_tag_message)
         print(LINE)
 
-        resp = fetch_history_from_github(github_user, github_project, last_tag)
+        resp = fetch_history_from_github(github_user, github_project, last_tag, main_branch)
         if resp["status"] != "ahead":
             print(f"Nothing to deploy! {resp['status']}")
             return


### PR DESCRIPTION
This requires users to configure `main_branch`, too.

Fixes #8.