### PR TITLE
Split line to make flake8 and black happy

### DIFF
--- a/release.py
+++ b/release.py
@@ -228,7 +228,8 @@ def run():
     current_branch = check_output("git rev-parse --abbrev-ref HEAD")
     if current_branch != main_branch:
         print(
-            f"Must be on the {main_branch} branch to do this; currently on {current_branch}"
+            f"Must be on the {main_branch} branch to do this;"
+            f" currently on {current_branch}"
         )
         return 1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,6 @@
 ignore =
     # E203: Whitespace before ':'; doesn't work with black
     E203,
-    # E501: line too long
-    E501,
     # W503: line break before operator; this doesn't work with black
     W503
 exclude = .git/


### PR DESCRIPTION
https://github.com/mozilla/ichnaea doesn't disable `E501`, so it complained about the length of a string that black considers OK. Split the string so that both black and flake8 (with `E501`) are happy.