### PR TITLE
Add markdown bits to tagged comment

### DIFF
--- a/release.py
+++ b/release.py
@@ -159,7 +159,11 @@ def make_tag(bug_number, remote_name, tag_name, commits_since_tag):
         output = check_output(f"git show {tag_name}")
         # Truncate the output at "diff --git"
         output = output[:output.find("diff --git")].strip()
+        print(f"Tagged {tag_name}:")
+        print("")
+        print("```")
         print(output)
+        print("```")
         print(">>> %<-----------------------------------------------")
 
 


### PR DESCRIPTION
This reduces the task of copying and pasting the tagged comment into
Bugzilla further.