### PR TITLE
Fix config for pyproject.toml

### DIFF
--- a/src/release.py
+++ b/src/release.py
@@ -97,6 +97,7 @@ def get_config():
             if config_data:
                 for key, default_val in my_config.items():
                     my_config[key] = config_data.get(key, default_val)
+                return my_config
 
     if os.path.exists("setup.cfg"):
         config = configparser.ConfigParser()


### PR DESCRIPTION
If the project has a `pyproject.toml` and a `setup.cfg`, then it would pick up whatever was in `setup.cfg`, but that's incorrect--it should pick up the configuration in `pyproject.toml`. This fixes that.