### PR TITLE
Replace hyphens with spaces in commit subject bug names

### DIFF
--- a/src/release.py
+++ b/src/release.py
@@ -345,7 +345,7 @@ def run():
         resp = fetch_history_from_github(github_user, github_project, first_commit)
 
     commits_since_tag = []
-    bug_name_prefix_regexp = re.compile("bug ([\d]+)", re.IGNORECASE)
+    bug_name_prefix_regexp = re.compile(r"bug-([\d]+)", re.IGNORECASE)
     for commit in resp["commits"]:
         # Skip merge commits
         if len(commit["parents"]) > 1:
@@ -361,7 +361,8 @@ def run():
         summary = summary[:80]
         # Bug 1868455: While GitHub autolinking doesn't suport spaces, Bugzilla autolinking
         # doesn't support hyphens.
-        summary = bug_name_prefix_regexp.sub(r"bug-\1", summary)
+        if args.cmd == "make-bug":
+            summary = bug_name_prefix_regexp.sub(r"bug \1", summary)
 
         # Figure out who did the commit prefering GitHub usernames
         who = commit["author"]


### PR DESCRIPTION
Because:
* We added GitHub autolinking for Bugzilla links in our crash ingestion repos (mozilla-services/socorro#6498), which only supports hyphens between "bug" and the bug number, not spaces.
* Conversely, Bugzilla only supports spaces and not hyphens.

This commit:
* Globally replaces any occurence of "bug-" with "bug ", case insensitive.

Closes: #38