### PR TITLE
Fix service-status.py so it works without requests (#42)

### DIFF
--- a/src/release.py
+++ b/src/release.py
@@ -31,8 +31,8 @@ import re
 import shlex
 import subprocess
 import sys
-from urllib.request import urlopen
 from urllib.parse import urlencode
+from urllib.request import urlopen
 
 
 DESCRIPTION = """

--- a/src/service-status.py
+++ b/src/service-status.py
@@ -25,8 +25,7 @@ import json
 import os
 import sys
 from urllib.parse import urlparse
-
-import requests
+from urllib.request import urlopen
 
 
 DESCRIPTION = """
@@ -83,20 +82,17 @@ def get_config():
 
 
 def fetch(url, is_json=True):
-    resp = requests.get(url)
-    if resp.status_code != 200:
-        print(url)
-        print(f"{resp.status_code}, {resp.content}")
-        raise Exception("Bad return code")
+    """Fetch data from a url
+
+    This raises URLError on HTTP request errors. It also raises JSONDecode
+    errors if it's not valid JSON.
+
+    """
+    fp = urlopen(url)
+    data = fp.read()
     if is_json:
-        try:
-            data = resp.content.strip()
-            data = data.replace(b"\n", b"")
-            return json.loads(data)
-        except json.decoder.JSONDecodeError:
-            print(data)
-            raise
-    return resp.content
+        return json.loads(data)
+    return data
 
 
 def fetch_history_from_github(main_branch, user, repo, from_sha):


### PR DESCRIPTION
This fixes `service-status.py` to work with just the Python standard libraries just like `release.py` does.

To test, copy this file over the equivalent one in socorro or one of the other services that has service-status configuration and then run `service-status.py` in that repository.

Fixes #42 