### PR TITLE
Extract bug numbers from commits and list them when using make-bug (#35)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,12 @@ help:
 	@echo "Available rules:"
 	@fgrep -h "##" Makefile | fgrep -v fgrep | sed 's/\(.*\):.*##/\1:  /'
 
+.PHONY: format
+format:  ## Format Python files
+	tox exec -e py38-lint -- ruff format
+
 .PHONY: lint
-lint:  ## Lint and reformat Python files
+lint:  ## Lint files
 	tox -e py38-lint
 
 .PHONY: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-src = ["src"]
+src = ["src", "tests"]
 target-version = "py38"
 
 [tool.ruff.lint]

--- a/src/license-check.py
+++ b/src/license-check.py
@@ -7,7 +7,7 @@
 """
 This script checks files for license headers.
 
-This requires Python 3 to run.
+This requires Python 3.8+ to run.
 
 See https://github.com/willkg/socorro-release/#readme for details.
 

--- a/src/service-status.py
+++ b/src/service-status.py
@@ -8,12 +8,12 @@
 This script looks at the ``/__version__`` endpoint information and tells you
 how far behind different server environments are from main tip.
 
-This requires Python 3 to run. See help text for more.
+This requires Python 3.8+ to run. See help text for more.
 
 See https://github.com/willkg/socorro-release/#readme for details.
 
-If you want to use ``pyproject.toml`` and you're using Python <3.11, this also
-requires the tomli library.
+Note: If you want to use ``pyproject.toml`` and you're using Python <3.11, this
+also requires the tomli library.
 
 repo: https://github.com/willkg/socorro-release/
 sha: $SHA$

--- a/tests/test_noop.py
+++ b/tests/test_noop.py
@@ -1,2 +1,0 @@
-def test_noop():
-    pass

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pytest
+
+import release
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        # No summary -> no bugs
+        ("", []),
+        # Single bug cases
+        ("bug-111111: summary", ["111111"]),
+        ("bug 111111: summary", ["111111"]),
+        # Multi bug cases
+        ("bug 111, 222: summary", ["111", "222"]),
+        ("bug 111 & 222: summary", ["111", "222"]),
+        ("bug 111, 222, 333: summary", ["111", "222", "333"]),
+        ("bug 111, 222, & 333: summary", ["111", "222", "333"]),
+        ("bug-111, bug-222, bug-333: summary", ["111", "222", "333"]),
+    ],
+)
+def test_bug_finding(data, expected):
+    assert release.find_bugs(data) == expected


### PR DESCRIPTION
This uses a similar regexp as the one we use in rob-bugson, but it's slimmed down to the specific needs of Observability Team.

This adds a test for `find_bugs()` which makes it a lot easier to make sure it works in the various scenarios.

Example output:

```
>>> Description
We want to do a deploy for `socorro-release-test` tagged `2024.02.26`.

It consists of the following commits:

`8ec7746`: Remove setup.cfg (willkg)
`15e8ca0`: bug 111111: add prod/stage crash-stats urls (willkg)
`9dd9cd6`: bug 1868132: update scripts (FAKE BUG) (willkg)
`6ad421d`: bug 222222: Update release.py (willkg)
`1d9e10b`: Update release.py script (willkg)
`5fc38f7`: support https (willkg)
`76e688e`: Update release.py (willkg)
`99f4a83`: Update release.py (willkg)
`92c4ce2`: bug 1111111: update release.py (willkg)
`a13b982`: bug 1231234: a second commit with a bug (willkg)
`8c52e28`: bug 1111111: second commit for one bug (willkg)
`fb7cd5f`: bug 1111111: another commit (willkg)
`01fac85`: 1231234: another commit (willkg)

Bugs referenced:

* bug #111111
* bug #1111111
* bug #1231234
* bug #1868132
* bug #222222
```

Bugzilla will autolink those bug numbers, indicate whether they're resolved or not, and also provide a on-hover tooltip with the bug summary.

![image](https://github.com/willkg/socorro-release/assets/820826/42abca8b-44e6-48fc-86d9-e262a5b158ec)
